### PR TITLE
improve documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v2.2.1 (TBD)
 
+Changes:
+
+- Generally proofread and improve documentation; both manpages and `holo --help`.
+
 Bugfixes:
 
 - Fix a bug in `holo-files` where `--force` wasn't required in all cases where it should be. (#40)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ test/cov.cov: clean-tests build/holo.test
 	@if s="$$(find cmd -type d -exec golint {} \; 2>/dev/null)" && test -n "$$s"; then printf ' => %s\n%s\n' golint "$$s"; false; fi
 	@$(GO) test $(GO_TESTFLAGS) -coverprofile=test/cov/holo-output.cov $(pkg)/cmd/holo/internal
 	@$(GO) test $(GO_TESTFLAGS) -coverprofile=test/cov/ssh-keys-output.cov $(pkg)/cmd/holo-ssh-keys/impl
+	@HOLO_BINARY="$$PWD/build/holo.test" HOLO_TEST_FLAGS="-test.coverprofile=$$PWD/test/cov/holo-help.cov" ./util/holo-test-help
 	@\
 		export HOLO_BINARY=../../../build/holo.test && \
 		export HOLO_TEST_COVERDIR=$(abspath test/cov) && \

--- a/cmd/holo/main.go
+++ b/cmd/holo/main.go
@@ -22,6 +22,7 @@ package entrypoint
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	impl "github.com/holocm/holo/cmd/holo/internal"
@@ -50,8 +51,8 @@ type Selector struct {
 func Main() (exitCode int) {
 	//a command word must be given as first argument
 	if len(os.Args) < 2 {
-		commandHelp()
-		return 0
+		commandHelp(os.Stderr)
+		return 2
 	}
 
 	//check that it is a known command word
@@ -72,9 +73,12 @@ func Main() (exitCode int) {
 	case "version", "--version":
 		fmt.Println(version)
 		return 0
-	default:
-		commandHelp()
+	case "help", "--help":
+		commandHelp(os.Stdout)
 		return 0
+	default:
+		commandHelp(os.Stderr)
+		return 2
 	}
 
 	return impl.WithCacheDirectory(func() (exitCode int) {
@@ -157,13 +161,14 @@ func Main() (exitCode int) {
 	}) //end of WithCacheDirectory
 }
 
-func commandHelp() {
+func commandHelp(w io.Writer) {
 	program := os.Args[0]
-	fmt.Printf("Usage: %s <operation> [...]\nOperations:\n", program)
-	fmt.Printf("    %s apply [-f|--force] [selector ...]\n", program)
-	fmt.Printf("    %s diff [selector ...]\n", program)
-	fmt.Printf("    %s scan [-s|--short|-p|--porcelain] [selector ...]\n", program)
-	fmt.Printf("\nSee `man 8 holo` for details.\n")
+	fmt.Fprintf(w, "Usage: %s apply [-f|--force] [selector ...]\n", program)
+	fmt.Fprintf(w, "   or: %s diff [selector ...]\n", program)
+	fmt.Fprintf(w, "   or: %s scan [-s|--short|-p|--porcelain] [selector ...]\n", program)
+	fmt.Fprintf(w, "   or: %s version\n", program)
+	fmt.Fprintf(w, "   or: %s help\n", program)
+	fmt.Fprintf(w, "\nSee `man 8 holo` for details.\n")
 }
 
 func commandApply(entities []*impl.Entity, options map[int]bool) (exitCode int) {

--- a/doc/holo-files.8.pod
+++ b/doc/holo-files.8.pod
@@ -14,7 +14,7 @@ overwrite or modify a file that has been installed by an application package.
 =head2 Structure of the resource directory
 
 Configuration packages that want to use this plugin must place files in the
-resource directory at F</usr/share/holo/files>. Each resource file works on a
+resource directory at F</usr/share/holo/files>. Each B<resource> file works on a
 certain B<target>, as determined by its file name:
 
     /usr/share/holo/files/20-webserver/etc/nginx/nginx.conf
@@ -24,12 +24,12 @@ certain B<target>, as determined by its file name:
                            |
                            +-- disambiguator
 
-The disambiguator is always required, and allows multiple resource files to
+The B<disambiguator> is always required, and allows multiple resource files to
 operate on the same target (sorted alphabetically by their disambiguator). The
 pattern of putting a number at the start of the disambiguator is not required,
 but useful to control the ordering of resource files.
 
-Each target file that has such resource files is an entity within Holo. Its entity
+Each target file that has such resource files is an B<entity> within Holo. Its entity
 name is C<file:$target> where C<$target> is the absolute path to the target
 file.
 
@@ -108,7 +108,7 @@ currently recognizes C<alpine>, C<arch>, C<debian>, C<fedora> and C<suse>.
 
 If there exist target bases below F</var/lib/holo/files> for which there are no
 corresponding resource files below F</usr/share/holo/files>, these target bases
-are considered orphaned.
+are considered B<orphaned>.
 
 This usually occurs because a package has been removed from the system, or
 because a different package version were installed that do not contain the

--- a/doc/holo-files.8.pod
+++ b/doc/holo-files.8.pod
@@ -8,8 +8,9 @@ holo-files - Holo plugin to provision files
 
 When using Holo, configuration is usually stored in system packages, so files
 can be provisioned by just including them in a configuration package. This
-plugin extends this basic capability to allow a configuration package to
-overwrite or modify a file that has been installed by an application package.
+plugin extends this basic capability to allow one package (a configuration
+package) to overwrite or modify a file that has been installed by another
+package (an application package).
 
 =head2 Structure of the resource directory
 
@@ -18,11 +19,11 @@ resource directory at F</usr/share/holo/files>. Each B<resource> file works on a
 certain B<target>, as determined by its file name:
 
     /usr/share/holo/files/20-webserver/etc/nginx/nginx.conf
-                           ^          --+------------------
-                           |            |
-                           |            +-- path to target
-                           |
-                           +-- disambiguator
+                          \__________/\___________________/
+                            |           |
+                            |           `-- path to target
+                            |
+                            `-- disambiguator
 
 The B<disambiguator> is always required, and allows multiple resource files to
 operate on the same target (sorted alphabetically by their disambiguator). The
@@ -30,7 +31,7 @@ pattern of putting a number at the start of the disambiguator is not required,
 but useful to control the ordering of resource files.
 
 Each target file that has such resource files is an B<entity> within Holo. Its entity
-name is C<file:$target> where C<$target> is the absolute path to the target
+ID is C<file:$target> where C<$target> is the absolute path to the target
 file.
 
 =head2 Application strategy
@@ -46,7 +47,7 @@ previous application step). The target contents will be piped through the
 script. This is typically used when the default configuration for an
 application shall be used, but with some minor modifications. The following
 example uses the default configuration for L<pacman(8)>, but enables the
-"Color" and "TotalDownload" option:
+"Color" and "TotalDownload" options:
 
     $ cat /usr/share/holo/files/20-enable-color/etc/pacman.conf.holoscript
     #!/bin/sh
@@ -95,6 +96,11 @@ its target base with this file:
 
     >> found updated target base: /etc/pacman.conf.pacnew -> /var/lib/holo/files/base/etc/pacman.conf
 
+(Unless disabled, it would not normally be nescessary to manually run C<sudo
+holo apply> in the above example, as holo-files provides a pacman hook that
+causes pacman to automatically call C<holo apply> to handle C<.pacnew> files.
+This is not (yet) true for other package managers.)
+
 This means that when configuration is applied as a holoscript on top of the
 default configuration, future updates to the default configuration will
 automatically be picked up, as long as C<holo apply> is run after the system update.
@@ -114,7 +120,7 @@ This usually occurs because a package has been removed from the system, or
 because a different package version were installed that do not contain the
 resource files in question anymore.
 
-There are two subcases to consider, If only configuration packages were
+There are two subcases to consider, if only configuration packages were
 deleted, C<holo apply> will restore the target base (as installed by the
 application package):
 
@@ -160,6 +166,8 @@ can be used to reset the target files to their defined state.
 =head1 SEE ALSO
 
 L<holo(8)> provides the user interface for using this plugin.
+
+L<os-release(5)>
 
 =head1 AUTHOR
 

--- a/doc/holo-files.8.pod
+++ b/doc/holo-files.8.pod
@@ -118,7 +118,7 @@ There are two subcases to consider, If only configuration packages were
 deleted, C<holo apply> will restore the target base (as installed by the
 application package):
 
-    Scrubbing file:/etc/resourcefile-deleted.conf (all resource files were deleted)
+    Scrubbing file:/etc/resourcefile-deleted.conf (all repository files were deleted)
       restore /var/lib/holo/files/base/etc/resourcefile-deleted.conf
 
 If the application package (to whom the target file belongs) has also been

--- a/doc/holo-files.8.pod
+++ b/doc/holo-files.8.pod
@@ -14,7 +14,7 @@ overwrite or modify a file that has been installed by an application package.
 =head2 Structure of the resource directory
 
 Configuration packages that want to use this plugin must place files in the
-resource directory at F</usr/share/holo/files>. Each source file works on a
+resource directory at F</usr/share/holo/files>. Each resource file works on a
 certain B<target>, as determined by its file name:
 
     /usr/share/holo/files/20-webserver/etc/nginx/nginx.conf
@@ -24,23 +24,23 @@ certain B<target>, as determined by its file name:
                            |
                            +-- disambiguator
 
-The disambiguator is always required, and allows multiple source files to
+The disambiguator is always required, and allows multiple resource files to
 operate on the same target (sorted alphabetically by their disambiguator). The
 pattern of putting a number at the start of the disambiguator is not required,
-but useful to control the ordering of source files.
+but useful to control the ordering of resource files.
 
-Each target file that has such source files is an entity within Holo. Its entity
+Each target file that has such resource files is an entity within Holo. Its entity
 name is C<file:$target> where C<$target> is the absolute path to the target
 file.
 
 =head2 Application strategy
 
-Source files are applied on the B<target base>, the initial version of the
+Resource files are applied on the B<target base>, the initial version of the
 target file that was found during the first C<holo apply> run. This target base
 is saved at F</var/lib/holo/files/base/$target>.
 
-Source files that are plain files or symlinks will just overwrite the target
-base (or all previous entries), whereas executable source files with an extra
+Resource files that are plain files or symlinks will just overwrite the target
+base (or all previous entries), whereas executable resource files with an extra
 C<.holoscript> suffix can be used to modify the target base (or the result of a
 previous application step). The target contents will be piped through the
 script. This is typically used when the default configuration for an
@@ -107,19 +107,19 @@ currently recognizes C<alpine>, C<arch>, C<debian>, C<fedora> and C<suse>.
 =head2 Handling package removal
 
 If there exist target bases below F</var/lib/holo/files> for which there are no
-corresponding source files below F</usr/share/holo/files>, these target bases
+corresponding resource files below F</usr/share/holo/files>, these target bases
 are considered orphaned.
 
 This usually occurs because a package has been removed from the system, or
 because a different package version were installed that do not contain the
-source files in question anymore.
+resource files in question anymore.
 
 There are two subcases to consider, If only configuration packages were
 deleted, C<holo apply> will restore the target base (as installed by the
 application package):
 
-    Scrubbing file:/etc/sourcefile-deleted.conf (all source files were deleted)
-      restore /var/lib/holo/files/base/etc/sourcefile-deleted.conf
+    Scrubbing file:/etc/resourcefile-deleted.conf (all resource files were deleted)
+      restore /var/lib/holo/files/base/etc/resourcefile-deleted.conf
 
 If the application package (to whom the target file belongs) has also been
 deleted, the target base will be deleted instead of restored:

--- a/doc/holo-files.8.pod
+++ b/doc/holo-files.8.pod
@@ -167,6 +167,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo-users-groups/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo-users-groups/issues
 
 =cut

--- a/doc/holo-plugin-interface.7.pod
+++ b/doc/holo-plugin-interface.7.pod
@@ -173,7 +173,7 @@ multiple C<SOURCE> lines can be printed.
 
 This link is only used internally to resolve resource file arguments into the
 entities defined by them. It is therefore considered good practice to list the
-source files a second time as informational text, with appropriate lower-case
+resource files a second time as informational text, with appropriate lower-case
 keys. The C<users-groups> plugin demonstrates this practice:
 
     ENTITY: group:sudo

--- a/doc/holo-plugin-interface.7.pod
+++ b/doc/holo-plugin-interface.7.pod
@@ -49,7 +49,14 @@ Old versions of Holo (prior to 1.2) required that the F</etc/holorc> be
 modified via L<holo-files(8)> through the use of post-install/upgrade/remove
 scripts. This is no longer required if holorc snippets are used.
 
-=head2 Runtime environment
+=head1 ENVIRONMENT
+
+Plugins SHALL locate and store their data in the directories named by the
+following environment variables:
+
+=over 4
+
+=item C<$HOLO_ROOT_DIR> (default: F</>)
 
 Plugins MUST recognize the environment variable C<$HOLO_ROOT_DIR>: If this
 variable exists, plugins SHALL assume that Holo is running in test mode. The
@@ -59,13 +66,6 @@ a normal root partition (at least the parts needed for the test scenario).
 In test mode, plugins SHOULD NOT talk to system-level daemons or write files
 outside the C<$HOLO_ROOT_DIR>. Appropriate mock implementations SHALL be used
 instead. Modifying files below C<$HOLO_ROOT_DIR> is allowed.
-
-=head3 C<$HOLO_RESOURCE_DIR>, C<$HOLO_STATE_DIR>, C<$HOLO_CACHE_DIR>
-
-Plugins SHALL locate and store their data in the directories named by the
-following environment variables:
-
-=over 4
 
 =item C<$HOLO_RESOURCE_DIR> (default: F<$HOLO_ROOT_DIR/usr/share/holo/$PLUGIN_ID>)
 
@@ -95,10 +95,13 @@ Holo, plugins SHALL always use the paths in the environment variables rather
 than trying to compute them by themselves. The paths are always given as
 absolute paths, and are located below C<$HOLO_ROOT_DIR> during test cases.
 
+=head1 EXECUTION
+
+The plugin binary is executed one or multiple times when Holo is run.
+
 =head2 The C<info> operation
 
-The plugin binary is executed one or multiple times when Holo is run. The first
-invocation is always with the single argument C<info>:
+The first invocation is always with the single argument C<info>:
 
     PLUGIN_BINARY=/usr/lib/holo/holo-$PLUGIN_ID
     $PLUGIN_BINARY info

--- a/doc/holo-plugin-interface.7.pod
+++ b/doc/holo-plugin-interface.7.pod
@@ -35,9 +35,18 @@ and C<foosql-users>.
 
 Plugins are not discovered automatically. They MUST be referenced in
 F<$HOLO_ROOT_DIR/etc/holorc> or F<$HOLO_ROOT_DIR/etc/holorc.d/*> (see
-L<holorc(5)>) by adding the line:
+L<holorc(5)>) by adding the line in one of the following forms:
 
     plugin $PLUGIN_ID
+    plugin $PLUGIN_ID=$PLUGIN_BINARY
+
+If the form without an explicit C<$PLUGIN_BINARY> is given, then Holo will use a
+default value of
+
+    PLUGIN_BINARY=/usr/lib/holo/holo-$PLUGIN_ID
+
+Note that this default value for C<$PLUGIN_BINARY> does NOT respect
+C<$HOLO_ROOT_DIR>.
 
 It is RECOMMENDED that plugins install a L<holorc(5)> snippet to achieve this:
 
@@ -52,19 +61,30 @@ scripts. This is no longer required if holorc snippets are used.
 =head1 ENVIRONMENT
 
 Plugins SHALL locate and store their data in the directories named by the
-following environment variables:
+following environment variables which are set by Holo before executing the
+plugin:
 
 =over 4
 
+=item C<$HOLO_API_VERSION> (default: C<3>)
+
+This variable is a single positive integer identifying the version of the API
+that the plugin is expected to conform to. Plugins SHALL not require that
+C<$HOLO_API_VERSION> be defined for the C<info> operation, but SHOULD verify
+that they support the specified version for all other operations.
+
 =item C<$HOLO_ROOT_DIR> (default: F</>)
 
-Plugins MUST recognize the environment variable C<$HOLO_ROOT_DIR>: If this
-variable exists, plugins SHALL assume that Holo is running in test mode. The
-variable holds the path to a directory which contains a test scenario resembling
-a normal root partition (at least the parts needed for the test scenario).
+Plugins MUST recognize the environment variable C<$HOLO_ROOT_DIR>: if this
+variable exists and is set to a value other than F</>, then plugins SHALL assume
+that Holo is running in test mode. The variable holds the path to a directory
+resembling a normal root partition (at least the parts needed for the test
+scenario).
 
-In test mode, plugins SHOULD NOT talk to system-level daemons or write files
-outside the C<$HOLO_ROOT_DIR>. Appropriate mock implementations SHALL be used
+In test mode, plugins SHOULD NOT talk to system-level daemons.  In test mode,
+plugins SHOULD NOT write files outside the C<$HOLO_ROOT_DIR>; with the exception
+of C<$HOLO_CACHE_DIR> (defined below), which may or may not be inside of
+C<$HOLO_ROOT_DIR>. Appropriate mock implementations SHALL be used
 instead. Modifying files below C<$HOLO_ROOT_DIR> is allowed.
 
 =item C<$HOLO_RESOURCE_DIR> (default: F<$HOLO_ROOT_DIR/usr/share/holo/$PLUGIN_ID>)
@@ -80,7 +100,7 @@ directory is missing, Holo will create it before calling the plugin executable.
 However, plugins are encouraged to create the state directory at their
 installation time if they are going to need it.
 
-=item C<$HOLO_CACHE_DIR> (default: below F</tmp>)
+=item C<$HOLO_CACHE_DIR> (default: below C<${TMPDIR:-/tmp}>)
 
 Where plugins may store temporary data, such as results from an initial scan
 operation. Holo will create this directory when it starts up, and clean it up
@@ -92,18 +112,19 @@ Future versions of Holo may start to choose these paths differently (or allow
 the user to do so), but the default values are stable and can safely be
 communicated to users in documentation. Because these paths can be chosen by
 Holo, plugins SHALL always use the paths in the environment variables rather
-than trying to compute them by themselves. The paths are always given as
-absolute paths, and are located below C<$HOLO_ROOT_DIR> during test cases.
+than trying to compute them by themselves. The paths may or may not be given as
+absolute paths, so plugins must be careful to handle relative paths correctly if
+they change directories during operation.
 
 =head1 EXECUTION
 
-The plugin binary is executed one or multiple times when Holo is run.
+The plugin binary is executed one or multiple times when Holo is run, each time
+with a different operation.
 
 =head2 The C<info> operation
 
 The first invocation is always with the single argument C<info>:
 
-    PLUGIN_BINARY=/usr/lib/holo/holo-$PLUGIN_ID
     $PLUGIN_BINARY info
 
 The plugin shall then report metadata about itself on stdout, as key-value
@@ -288,7 +309,9 @@ C<$HOLO_CACHE_DIR>. An example of this is the C<holo-users-groups> plugin.
 
 =head1 SEE ALSO
 
-L<holo(8)>, L<holo-test(7)> (test runner for Holo plugins)
+L<holo(8)>, L<holorc(5)>
+
+L<holo-test(7)> (test runner for Holo plugins)
 
 =head1 AUTHOR
 

--- a/doc/holo-plugin-interface.7.pod
+++ b/doc/holo-plugin-interface.7.pod
@@ -292,6 +292,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo/issues
 
 =cut

--- a/doc/holo-plugin-interface.7.pod
+++ b/doc/holo-plugin-interface.7.pod
@@ -59,27 +59,27 @@ In test mode, plugins SHOULD NOT talk to system-level daemons or write files
 outside the C<$HOLO_ROOT_DIR>. Appropriate mock implementations SHALL be used
 instead. Modifying files below C<$HOLO_ROOT_DIR> is allowed.
 
-=head3 HOLO_RESOURCE_DIR, HOLO_STATE_DIR, HOLO_CACHE_DIR
+=head3 C<$HOLO_RESOURCE_DIR>, C<$HOLO_STATE_DIR>, C<$HOLO_CACHE_DIR>
 
 Plugins SHALL locate and store their data in the directories named by the
 following environment variables:
 
 =over 4
 
-=item HOLO_RESOURCE_DIR (default: `/usr/share/holo/$PLUGIN_ID`)
+=item C<$HOLO_RESOURCE_DIR> (default: F</usr/share/holo/$PLUGIN_ID>)
 
 Where plugins can find their resources. Holo will refuse to operate if the
 resource directory does not exist, thus plugins SHOULD create the default
 path at installation time.
 
-=item HOLO_STATE_DIR (default: `/var/lib/holo/$PLUGIN_ID`)
+=item C<$HOLO_STATE_DIR> (default: F</var/lib/holo/$PLUGIN_ID>)
 
 Where plugins can store persistent state between runs of Holo. If the state
 directory is missing, Holo will create it before calling the plugin executable.
 However, plugins are encouraged to create the state directory at their
 installation time if they are going to need it.
 
-=item HOLO_CACHE_DIR (default: below `/tmp`)
+=item C<$HOLO_CACHE_DIR> (default: below F</tmp>)
 
 Where plugins may store temporary data, such as results from an initial scan
 operation. Holo will create this directory when it starts up, and clean it up
@@ -273,14 +273,14 @@ applied by the plugin (i.e., the state the plugin expects it to currently be
 in), the second file represents the actual current state of the entity.
 
 The plugin is allowed to return paths that do not exist in the file system, in
-which case Holo will diff against `/dev/null` instead. `/dev/null` can also be
+which case Holo will diff against F</dev/null> instead. F</dev/null> can also be
 given explicitly instead of a file that is missing. (The first file will be
 missing when the entity is orphaned, and the second file will be missing when
 the entity was deleted by the user or an external program.)
 
 For entities that are not backed by a file, the plugin is allowed to make up a
 useful textual representation of the entity, and write appropriate files to the
-C<HOLO_CACHE_DIR>. An example of this is the C<holo-users-groups> plugin.
+C<$HOLO_CACHE_DIR>. An example of this is the C<holo-users-groups> plugin.
 
 =head1 SEE ALSO
 

--- a/doc/holo-plugin-interface.7.pod
+++ b/doc/holo-plugin-interface.7.pod
@@ -34,13 +34,14 @@ by multiple plugins, appropriate plugin IDs could include C<foosql-databases>
 and C<foosql-users>.
 
 Plugins are not discovered automatically. They MUST be referenced in
-F</etc/holorc> (see L<holorc(5)>) by adding the line:
+F<$HOLO_ROOT_DIR/etc/holorc> or F<$HOLO_ROOT_DIR/etc/holorc.d/*> (see
+L<holorc(5)>) by adding the line:
 
     plugin $PLUGIN_ID
 
 It is RECOMMENDED that plugins install a L<holorc(5)> snippet to achieve this:
 
-    $ cat /etc/holorc.d/50-foosql
+    $ cat $HOLO_ROOT_DIR/etc/holorc.d/50-foosql
     # This file is part of the holo-foosql package.
     plugin foosql
 
@@ -66,13 +67,13 @@ following environment variables:
 
 =over 4
 
-=item C<$HOLO_RESOURCE_DIR> (default: F</usr/share/holo/$PLUGIN_ID>)
+=item C<$HOLO_RESOURCE_DIR> (default: F<$HOLO_ROOT_DIR/usr/share/holo/$PLUGIN_ID>)
 
 Where plugins can find their resources. Holo will refuse to operate if the
 resource directory does not exist, thus plugins SHOULD create the default
 path at installation time.
 
-=item C<$HOLO_STATE_DIR> (default: F</var/lib/holo/$PLUGIN_ID>)
+=item C<$HOLO_STATE_DIR> (default: F<$HOLO_ROOT_DIR/var/lib/holo/$PLUGIN_ID>)
 
 Where plugins can store persistent state between runs of Holo. If the state
 directory is missing, Holo will create it before calling the plugin executable.

--- a/doc/holo-run-scripts.8.pod
+++ b/doc/holo-run-scripts.8.pod
@@ -29,6 +29,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo-run-scripts/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo-run-scripts/issues
 
 =cut

--- a/doc/holo-ssh-keys.8.pod
+++ b/doc/holo-ssh-keys.8.pod
@@ -33,7 +33,7 @@ C<holo=$entity_name>.
 
 Applying a key file entity will also remove all keys from
 C<.ssh/authorized_keys> which are tagged with this entity name, but are not
-present in the source file for this entity. Keys can thus be replaced in or
+present in the resource file for this entity. Keys can thus be replaced in or
 removed from the key file, and all changes will be propagated into
 C<.ssh/authorized_keys> automatically (without requiring C<--force>).
 

--- a/doc/holo-ssh-keys.8.pod
+++ b/doc/holo-ssh-keys.8.pod
@@ -47,6 +47,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo-ssh-keys/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo-ssh-keys/issues
 
 =cut

--- a/doc/holo-test.7.pod
+++ b/doc/holo-test.7.pod
@@ -119,6 +119,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo/issues
 
 =cut

--- a/doc/holo-users-groups.8.pod
+++ b/doc/holo-users-groups.8.pod
@@ -115,6 +115,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo-users-groups/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo-users-groups/issues
 
 =cut

--- a/doc/holo.8.pod
+++ b/doc/holo.8.pod
@@ -132,6 +132,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo/issues
 
 =cut

--- a/doc/holo.8.pod
+++ b/doc/holo.8.pod
@@ -60,13 +60,16 @@ multiple entities.
 Each entity is identified by a name, usually of the form C<type:identifier>.
 Refer to the manpage of each plugin for the format for its entities' names.
 
+An entity that was created and still exists, but for which all source files have
+been removed, is said to be B<orphaned> or an B<orphan>. Orphaned entities are
+removed the next time an apply operation is performed on them.
+
 =head1 OPERATIONS
 
 All operations act on all entities by default, but can be restricted to certain
-entities by giving B<selectors> on the command line.
-
-A selector can be either an entity name (such as C<file:/etc/sddm/sddm.conf>),
-or the path to a resource file that defines this entity (for instance,
+entities by giving B<selectors> on the command line. A selector can be either an
+entity name (such as C<file:/etc/sddm/sddm.conf>), or the path to a resource
+file that defines this entity (such as
 C</usr/share/holo/files/40-desktop/etc/sddm/sddm.conf>), or a plugin ID (such
 as C<files>). A plugin ID as selector matches all entities known to that
 plugin.
@@ -79,11 +82,11 @@ Prompt all plugins to scan for entities and list all known entities (or, if
 selectors are given, all entities matching these selectors) including the
 information returned from plugins about these entities.
 
-With C<--short>, only list the entity names.
+With C<-s> or C<--short>, only list the entity names.
 
-With C<--porcelain>, show the raw scan report as received from the plugins. The
-format is documented in L<holo-plugin-interface(7)>. The format is more
-machine-readable and stable, and thus the preferred choice for parsing in
+With C<-p> or C<--porcelain>, show the raw scan report as received from the
+plugins. The format is documented in L<holo-plugin-interface(7)>. The format is
+more machine-readable and stable, and thus the preferred choice for parsing in
 scripts.
 
 =item B<apply> [I<-f|--force>] [I<selector> ...]
@@ -91,17 +94,17 @@ scripts.
 Apply the selected (or all) entities. Refer to the manpage of each plugin for
 what "applying" entails.
 
-By default, Holo will refuse to provision entities that have been changed by the
-user or by other programs. Apply B<--force> to overwrite such changes or perform
-otherwise dangerous activities.
+By default, Holo plugins will refuse to provision entities that have been
+changed by the user or by other programs. Apply C<-f> or C<--force> to overwrite
+such changes or perform otherwise dangerous activities.
 
 If you want to check what will be done, use C<holo scan> as a dry run before
 C<holo apply>.
 
 =item B<diff> [I<selector> ...]
 
-Print a L<diff(1)> between the last provisioned version of each selected target
-file and the actual contents of that target file.
+Print a L<diff(1)> between the last provisioned version of each selected entity
+and the actual contents of that entity.
 
 For entities that are not files, refer to the plugin's manpage for what the
 diff contains. When a plugin is not able to produce a meaningful textual
@@ -117,7 +120,43 @@ Print out Holo's version string including the release name.
 
 =back
 
+=head1 ENVIRONMENT
+
+=over 4
+
+=item C<$TMPDIR> (default: F</tmp>)
+
+Where to place temporary files.
+
+=back
+
+=head1 FILES
+
+=over 4
+
+=item F</etc/holorc> (see L<holorc(5)>)
+
+=item F</etc/holorc.d/*> (see L<holorc(5)>)
+
+=item F</run/holo.pid>
+
+=back
+
+For each plugin:
+
+=over 4
+
+=item F</usr/lib/holo/holo-$PLUGIN_ID> (can be overridden in L<holorc(5)>)
+
+=item F</usr/share/holo/$PLUGIN_ID/> (must exist)
+
+=item F</var/lib/holo/$PLUGIN_ID/> (will be created if does not exist)
+
+=back
+
 =head1 SEE ALSO
+
+L<holorc(5)>
 
 L<holo-build(8)> can optionally be used in conjunction with Holo to simplify
 the package build process.

--- a/doc/holo.8.pod
+++ b/doc/holo.8.pod
@@ -12,7 +12,9 @@ holo B<diff> [I<selector> ...]
 
 holo B<scan> [I<-s|--short|-p|--porcelain>] [I<selector> ...]
 
-holo B<--help|--version>
+holo B<help>
+
+holo B<version>
 
 =head1 DESCRIPTION
 
@@ -105,17 +107,11 @@ For entities that are not files, refer to the plugin's manpage for what the
 diff contains. When a plugin is not able to produce a meaningful textual
 representation of the entity, no output will be produced for its entities.
 
-=back
-
-=head1 OPTIONS
-
-=over 4
-
-=item B<--help>
+=item B<help>
 
 Print out usage information.
 
-=item B<--version>
+=item B<version>
 
 Print out Holo's version string including the release name.
 

--- a/doc/holo.8.pod
+++ b/doc/holo.8.pod
@@ -45,16 +45,16 @@ C<.ssh/authorized_keys>, and the L<holo-users-groups(8)> plugin which
 provisions user accounts and groups to the standard L<passwd(5)> and
 L<group(5)> databases.
 
-=head2 Entities, source files
+=head2 Entities, resource files
 
 Holo calls the things that it works on B<entities>. Each entity belongs to a
 certain plugin, since plugins contain all the logic for discovering and working
 on entities.
 
-Entities are defined in B<source files> which configuration packages install
-into the resource directory of the corresponding plugin (at
+Entities are defined in B<source> or B<resource files> which configuration
+packages install into the resource directory of the corresponding plugin (at
 F</usr/share/holo/$PLUGIN_ID>). Depending on how the plugin works, a single
-entity may have multiple source files, or a single source file might define
+entity may have multiple resource files, or a single resource file might define
 multiple entities.
 
 Each entity is identified by a name, usually of the form C<type:identifier>.
@@ -66,7 +66,7 @@ All operations act on all entities by default, but can be restricted to certain
 entities by giving selectors on the command line.
 
 A selector can be either an entity name (such as C<file:/etc/sddm/sddm.conf>),
-or the path to a source file that defines this entity (for instance,
+or the path to a resource file that defines this entity (for instance,
 C</usr/share/holo/files/40-desktop/etc/sddm/sddm.conf>), or a plugin ID (such
 as C<files>). A plugin ID as selector matches all entities known to that
 plugin.

--- a/doc/holo.8.pod
+++ b/doc/holo.8.pod
@@ -63,7 +63,7 @@ Refer to the manpage of each plugin for the format for its entities' names.
 =head1 OPERATIONS
 
 All operations act on all entities by default, but can be restricted to certain
-entities by giving selectors on the command line.
+entities by giving B<selectors> on the command line.
 
 A selector can be either an entity name (such as C<file:/etc/sddm/sddm.conf>),
 or the path to a resource file that defines this entity (for instance,

--- a/doc/holorc.5.pod
+++ b/doc/holorc.5.pod
@@ -61,6 +61,6 @@ Stefan Majewsky
 
 Further documentation is available at the project homepage: http://holocm.org
 
-Please report any issues and feature requests at Github: http://github.com/holocm/holo/issues
+Please report any issues and feature requests at GitHub: http://github.com/holocm/holo/issues
 
 =cut

--- a/doc/holorc.5.pod
+++ b/doc/holorc.5.pod
@@ -15,26 +15,36 @@ holorc, holorc.d - configuration file for L<holo(8)>
 The holorc file defines which plugins will be loaded and used by Holo, and in
 which order. Blank lines, and comment lines starting with a C<#> character are ignored.
 
-The format of each command line is:
+Non-blank and non-comment lines can be of one of two forms:
 
     plugin $PLUGIN_ID
+    plugin $PLUGIN_ID=$PLUGIN_BINARY
 
-where C<$PLUGIN_ID> is the alphanumeric identifier of the plugin. The plugin identifier is
-encoded in several paths that are relevant for the plugin:
+where C<$PLUGIN_ID> is the alphanumeric identifier of the plugin, and
+C<$PLUGIN_BINARY> is the path to the plugin executable file.  If the
+form without an explicit C<$PLUGIN_BINARY> is given, then Holo will
+use a default value of
+
+    PLUGIN_BINARY=/usr/lib/holo/holo-$PLUGIN_ID
+
+The plugin identifier is encoded in several paths that are relevant
+for the plugin:
 
 =over 4
 
-=item *
+=item F</usr/lib/holo/holo-$PLUGIN_ID>
 
-The plugin executable is installed at F</usr/lib/holo/holo-$PLUGIN_ID>.
+Unless C<$PLUGIN_BINARY> is explicitly specified, this is plugin
+executable is installed at.
 
-=item *
+=item F</usr/share/holo/$PLUGIN_ID/>
 
-Configuration packages install resources for this plugin below F</usr/share/holo/$PLUGIN_ID/>.
+Configuration packages install resources for this plugin below this
+directory.
 
-=item *
+=item F</var/lib/holo/$PLUGIN_ID/>
 
-The plugin stores its state at F</var/lib/holo/$PLUGIN_ID/>.
+The plugin stores its persistent state at in the directory.
 
 =back
 

--- a/test/README.md
+++ b/test/README.md
@@ -10,3 +10,19 @@ The test cases are run with `holo-test`, which is documented in its manpage at
 repository root:
 
     ./util/holo-test holo ./test/??-*
+
+There are several test-hooks built in to the binaries:
+
+ - `holo-files` also supports the `unittest` os-release ID, which disables
+   package-manager specific functionality.
+
+ - The environment variable `$HOLO_TEST_FLAGS` can be used to send flags to the
+   testing subsystem (that is, the "testing" Go package). Documentation on
+   supported test flags can be accessed by running `HOLO_TEST_FLAGS=-help
+   ./bin/holo.test`.
+
+ - The environment variable `$HOLO_TEST_COVERDIR` can be used to augment
+   `$HOLO_TEST_FLAGS`. At process start up, the program will insert
+   `-test.coverprofile $HOLO_TEST_COVERDIR/$UNIQ_FILE` into the flags passed to
+   the testing subsystem, where `$UNIQ_FILE` is a identifier unique to that
+   process invocation.

--- a/util/holo-test-help
+++ b/util/holo-test-help
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Copyright 2015-2017 Stefan Majewsky <majewsky@gmx.net>
+# Copyright 2018 Luke Shumaker <lukeshu@parabola.nu>
+#
+# This file is part of Holo.
+#
+# Holo is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# Holo is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# Holo. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# by default, use installed Holo binary
+: ${HOLO_BINARY:=holo}
+
+empty() {
+    [[ -f "$1" && ! -s "$1" ]]
+}
+
+notempty() {
+    [[ -s "$1" ]]
+}
+
+# Create and chdir to a scratch temporary directory
+tmpdir=$(mktemp -td "${0##*/}".XXXXXXXXXX) || exit
+trap 'cd / && rm -rf -- "$tmpdir"' EXIT
+cd "$tmpdir"
+
+# In case we ever localize Holo, we want it to say "Usage:" for these
+# tests
+export LC_ALL=C
+
+# Don't check the full usage or version or error text--let's leave
+# that free to improve without needing to update the tests.  Just
+# check the general format of things; "is the exit code 0?", "was
+# anything on stdout?", "or stderr?"
+run_holo() {
+    echo ">> Running test case $TEST_NAME..."
+    declare -ig r=0
+    $HOLO_BINARY "$@" >stdout 2>stderr || r=$?
+    exec >& setx
+    set -x
+}
+fail() {
+    cat setx
+    echo "!! The above check failed"
+    TEST_EXIT_CODE=1
+}
+TEST_EXIT_CODE=0
+TEST_NAME='no args'      && ( run_holo            && test $r != 0 && empty stdout                     && notempty stderr ) || fail
+TEST_NAME='bogus op'     && ( run_holo frob       && test $r != 0 && empty stdout                     && notempty stderr ) || fail
+TEST_NAME='bogus flag'   && ( run_holo --frob     && test $r != 0 && empty stdout                     && notempty stderr ) || fail
+TEST_NAME='help op'      && ( run_holo help       && test $r == 0 && [[ "$(cat stdout)" == Usage:* ]] && empty stderr    ) || fail
+TEST_NAME='help flag'    && ( run_holo --help     && test $r == 0 && [[ "$(cat stdout)" == Usage:* ]] && empty stderr    ) || fail
+TEST_NAME='version op'   && ( run_holo version    && test $r == 0 && notempty stdout                  && empty stderr    ) || fail
+TEST_NAME='version flag' && ( run_holo --version  && test $r == 0 && notempty stdout                  && empty stderr    ) || fail
+
+TESTED_THING='holo help text'
+if [ $TEST_EXIT_CODE = 0 ]; then
+    echo ">> All tests for $TESTED_THING completed successfully."
+else
+    echo "!! Some or all tests for $TESTED_THING failed. Please check the output above for more information."
+fi
+exit $TEST_EXIT_CODE


### PR DESCRIPTION
I just read through it, fixing it up as I went.

The recurring items:

 - "GitHub", not "Github"
 - Be careful to avoid introducing unnecessary new terms.  We already
   call them "resources", no need to also start calling them
   "sources".  Same with "entity"/"target".  And when we do introduce
   a new term, bold it.

The bigger other things:

 - Have `holo help` be a bit more like other programs
 - holo-plugin-interface(7): be more explicit about interaction with
   $HOLO_ROOT_DIR.
 - holo-plugin-interface(7): correct lies about paths always being absolute

Beyond that, a bunch of small punctuation and wording improvements.

I actually did most of this before run-scripts/ssh-keys/users-groups
were merged into this repo; hence those manpages being a bit neglected
in this patch.