### PR TITLE
holo-test: Explicitly set `umask 022`

### DIFF
--- a/util/holo-test
+++ b/util/holo-test
@@ -24,6 +24,8 @@ ORIGINAL_CWD="$PWD"
 : ${HOLO_BINARY:=holo}
 : ${HOLO_TEST_SCRIPTPATH:=/usr/lib/holo}
 
+umask 022
+
 if ! type colordiff &>/dev/null; then
     colordiff() {
         cat


### PR DESCRIPTION
On a different PR, I got test failure apparently unrelated to the changes
that I had made.

Looking at the test output, it was showing directories with mode 775
instead of the expected 755; which suggests to me that the testcase assumes
umask 022, and that the code was running with a different umask.

So I would guess that the 2017-12-12 update to the default images used by
Travis changed the default umask from 022 to 002; though I have found no
documentation of that.

    https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch

Anyway, I verified locally that setting `umask 002` allows me to reproduce
the errors I'm getting from Travis, so regardless of the cause, we
shouldn't let tests fail based on the user's umask setting.