### PR TITLE
holo-files: Fix subtle bug where it didn't require `--force` when it should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v2.2.1 (TBD)
+
+Bugfixes:
+
+- Fix a bug in `holo-files` where `--force` wasn't required in all cases where it should be. (#40)
+- Fix a bug in `holo-files` where, in some situations, it wrote the wrong thing to the persistent state directory,
+  causing incorrect results on future calls to `holo apply`. (#40)
+
 # v2.2 (2017-12-07)
 
 Changes:

--- a/cmd/holo-files/internal/impl/entity_apply_nonorphan.go
+++ b/cmd/holo-files/internal/impl/entity_apply_nonorphan.go
@@ -89,7 +89,7 @@ func (entity *Entity) applyNonOrphan(withForce bool) (skipReport bool, err error
 		}
 		tmp := current
 		tmp.Path = base.Path
-		base = current
+		base = tmp
 	}
 
 	if !base.Manageable {
@@ -129,9 +129,15 @@ func (entity *Entity) applyNonOrphan(withForce bool) (skipReport bool, err error
 		return false, err
 	}
 
-	//compare it against the last provisioned version (which must exist at this point
-	//unless we are using --force)
-	if provisioned.Manageable && !(current.EqualTo(provisioned) || current.EqualTo(desired)) {
+	//compare it against the current expected state (a reference
+	//file for this must exist at this point); normally this will
+	//be the last-provisioned version, but if we've never
+	//provisioned it before, then it is the base version
+	expected := provisioned
+	if !provisioned.Manageable {
+		expected = base
+	}
+	if !(current.EqualTo(expected) || current.EqualTo(desired)) {
 		if !withForce {
 			return false, ErrNeedForceToOverwrite
 		}

--- a/test/files/16-new-entity-apply/README.md
+++ b/test/files/16-new-entity-apply/README.md
@@ -1,0 +1,8 @@
+This testcase checks that when Holo is
+ 1. first provisioning a file that Holo has never touched before, and
+ 2. a system-update has already left a new stock version (a `.pacnew`
+    file in this test) because of user modification,
+that Holo correctly recognizes
+ 1. that the UpdatedTargetBase is the base version, and
+ 2. that `--force` should be required to wipe out the user
+    modifications.

--- a/test/files/16-new-entity-apply/expected-apply-force-output
+++ b/test/files/16-new-entity-apply/expected-apply-force-output
@@ -1,0 +1,6 @@
+
+Working on file:/etc/foo.conf
+  store at target/var/lib/holo/files/base/etc/foo.conf
+  passthru target/usr/share/holo/files/01-first/etc/foo.conf.holoscript
+
+exit status 0

--- a/test/files/16-new-entity-apply/expected-apply-output
+++ b/test/files/16-new-entity-apply/expected-apply-output
@@ -1,0 +1,16 @@
+
+Working on file:/etc/foo.conf
+  store at target/var/lib/holo/files/base/etc/foo.conf
+  passthru target/usr/share/holo/files/01-first/etc/foo.conf.holoscript
+
+>> found updated target base: target/etc/foo.conf.pacnew -> target/var/lib/holo/files/base/etc/foo.conf
+!! Entity has been modified by user (use --force to overwrite)
+
+    diff --holo target/var/lib/holo/files/provisioned/etc/foo.conf target/etc/foo.conf
+    new file mode 100644
+    --- /dev/null
+    +++ target/etc/foo.conf
+    @@ -0,0 +1 @@
+    +user
+
+exit status 0

--- a/test/files/16-new-entity-apply/expected-diff-output
+++ b/test/files/16-new-entity-apply/expected-diff-output
@@ -1,0 +1,7 @@
+diff --holo target/var/lib/holo/files/provisioned/etc/foo.conf target/etc/foo.conf
+new file mode 100644
+--- /dev/null
++++ target/etc/foo.conf
+@@ -0,0 +1 @@
++user
+exit status 0

--- a/test/files/16-new-entity-apply/expected-scan-output
+++ b/test/files/16-new-entity-apply/expected-scan-output
@@ -1,0 +1,6 @@
+
+file:/etc/foo.conf
+    store at target/var/lib/holo/files/base/etc/foo.conf
+    passthru target/usr/share/holo/files/01-first/etc/foo.conf.holoscript
+
+exit status 0

--- a/test/files/16-new-entity-apply/expected-tree
+++ b/test/files/16-new-entity-apply/expected-tree
@@ -1,0 +1,26 @@
+file      0644 ./etc/foo.conf
+system
+hologram
+----------------------------------------
+symlink   0777 ./etc/holorc
+../../../holorc
+----------------------------------------
+file      0644 ./etc/os-release
+ID=arch
+----------------------------------------
+directory 0755 ./run/
+----------------------------------------
+directory 0755 ./tmp/
+----------------------------------------
+file      0755 ./usr/share/holo/files/01-first/etc/foo.conf.holoscript
+#!/bin/sh
+cat
+echo hologram
+----------------------------------------
+file      0644 ./var/lib/holo/files/base/etc/foo.conf
+system
+----------------------------------------
+file      0644 ./var/lib/holo/files/provisioned/etc/foo.conf
+system
+hologram
+----------------------------------------

--- a/test/files/16-new-entity-apply/source-tree
+++ b/test/files/16-new-entity-apply/source-tree
@@ -1,0 +1,17 @@
+file      0644 ./etc/foo.conf
+user
+----------------------------------------
+file      0644 ./etc/foo.conf.pacnew
+system
+----------------------------------------
+symlink   0777 ./etc/holorc
+../../../holorc
+----------------------------------------
+file      0644 ./etc/os-release
+ID=arch
+----------------------------------------
+file      0755 ./usr/share/holo/files/01-first/etc/foo.conf.holoscript
+#!/bin/sh
+cat
+echo hologram
+----------------------------------------


### PR DESCRIPTION
I was working on implementing patch files (#5), when I noticed the

    base = current

line, which should obviously be

    base = tmp

But if you fix the bug without writing a test, is it really fixed?  So then
I went about trying to figure out how to trigger misbehavior based on that
mistake.  In doing so, I found a second bug, when my test very clearly
should have required `--force`, but it didn't.

The fixes to both bugs are required to make the added test pass.