### PR TITLE
Update my email address in copyright notices

### DIFF
--- a/cmd/holo-files/internal/impl/entity_apply_nonorphan.go
+++ b/cmd/holo-files/internal/impl/entity_apply_nonorphan.go
@@ -1,7 +1,7 @@
 /*******************************************************************************
 *
 * Copyright 2015 Stefan Majewsky <majewsky@gmx.net>
-* Copyright 2017 Luke Shumaker <lukeshu@sbcglobal.net>
+* Copyright 2017 Luke Shumaker <lukeshu@parabola.nu>
 *
 * This file is part of Holo.
 *

--- a/cmd/holo-files/internal/impl/resource.go
+++ b/cmd/holo-files/internal/impl/resource.go
@@ -1,7 +1,7 @@
 /*******************************************************************************
 *
 * Copyright 2015 Stefan Majewsky <majewsky@gmx.net>
-* Copyright 2017 Luke Shumaker <lukeshu@sbcglobal.net>
+* Copyright 2017 Luke Shumaker <lukeshu@parabola.nu>
 *
 * This file is part of Holo.
 *


### PR DESCRIPTION
Because of numerous issues with it, I'd like my @sbcglobal.net email
address to not be listed anywhere anymore.  And, in most places in holo, I
was using my @parabola.nu anyway--even in other files in the same commit
that added these 2 @sbcglobal.net instances.