### PR TITLE
holo-ssh-keys: Remove code working around openssh < 6.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
     - go get -u github.com/mattn/goveralls
 
 script:
-    - make && env IS_TRAVIS=1 make check
+    - make && make check
 after_success:
     - goveralls -coverprofile=test/cov.cov -service=travis-ci

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -16,6 +16,9 @@ Build-time dependencies for this repo:
 * `go`
 * `perl` (for `make check`, and compiling the manpages)
 
+The test suite requires at least version 6.8 of openssh, but this
+version requirement is is not nescessary for actual use.
+
 ## Configuration files
 
 `/etc/holorc` and `/etc/holorc.d/*` should be marked as configuration files.

--- a/cmd/holo-ssh-keys/impl/scan.go
+++ b/cmd/holo-ssh-keys/impl/scan.go
@@ -129,32 +129,7 @@ func scanDirectory(path string, entityNameWasSeen *map[string]bool) []error {
 	return errs
 }
 
-var testFingerprintsForTravis = map[string]string{
-	//generated with:
-	//    for file in test/ssh-keys/data/key?.pub; do printf '"%s": "%s",\n' $(awk '{print$3}' $file) "$(ssh-keygen -l -f $file)"; done
-	"user@key0": "2048 SHA256:BPwneuiBV/tqWEUSKBdXI1uFAgwP5J5Opw17Gw7xEkY user@key0 (RSA)",
-	"user@key1": "2048 SHA256:INu+TuczyJpYs1IiMb6csykJDbJ778oJeXmG40WCCHI user@key1 (RSA)",
-	"user@key2": "2048 SHA256:Q1TXZxElJ9fjGiEKkJq91tgeCRFNSzlsCnJeoCA66s4 user@key2 (RSA)",
-	"user@key3": "2048 SHA256:bb8t1lzOwTyq6dy93w7ClVFbd3iLAh82fgLLVqcJKbA user@key3 (RSA)",
-	"user@key4": "2048 SHA256:lYeUIQDlaTvELtUetbv53Aeo2mWTpRsGlBAl8NnlFhc user@key4 (RSA)",
-	"user@key5": "2048 SHA256:aCyg59ac9DRUeyhtunS6y+ndOA6Ne5Yr54WxKtwPuKQ user@key5 (RSA)",
-	"user@key6": "2048 SHA256:FHs9PBF87NiNLHYz46cE3PK4QaIkrhAD2LqjLeVppA4 user@key6 (RSA)",
-	"user@key7": "2048 SHA256:dS/mERwxCjygV7+mrgTM/eB0EsxVRShmHVgEG/VoBuc user@key7 (RSA)",
-	"user@key8": "2048 SHA256:vyhBF5fEOl3z3H9vvQunNqwwZgKxd9KHc1SHXX9w1uA user@key8 (RSA)",
-	"user@key9": "2048 SHA256:ZSVr6fO2K67yEXR/4wT/5cvvWc8wsOzQvWDwgEZQ1Os user@key9 (RSA)",
-}
-
 func getFingerprint(key *Key) (string, error) {
-	//Travis has an SSH that is too old and cannot generate SHA256
-	//fingerprints; to get a consistent scan-output, use pre-generated
-	//fingerprints in that case
-	if rootDir != "/" && os.Getenv("IS_TRAVIS") != "" { //test mode, extra env variable set by .travis.yml
-		result := testFingerprintsForTravis[key.Comment]
-		if result != "" {
-			return result, nil
-		}
-	}
-
 	//`ssh-keygen` cannot read the key from stdin for whatever reason, so use a temporary file
 	file, err := ioutil.TempFile("/tmp/", "holo-ssh-key")
 	if err != nil {


### PR DESCRIPTION
Prior to OpenSSH 6.8 (2015-03-18), ssh-keygen used MD5 for fingerprints.
In 6.8 that became configurable (FingerprintHash, the `-E` flag), and
started using SHA256 by default.

The fingerprints are informational; using a different FingerprintHash has
no affect on the operation of Holo.  However, the tests inspect the full
output; they expect it to use SHA256.

That part of holo-ssh-keys was written in 2015-12; of course Travis wasn't
shipping 6.8 yet.  But I'm pretty sure they are now!

(If CI comes back and proves me wrong, I'll just delete the pull request)