### PR TITLE
Run tests in parallel, automatically detect which packages need `go test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 /.version
 .golangvend-cache/
+go-test.cov

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ build/man/%: doc/%.pod .version | build/man
 		$< $@
 
 test: check # just a synonym
+.PHONY: test
+
 check: default test/cov.html test/cov.func.txt
+.PHONY: check
+
 test/cov.cov: clean-tests build/holo.test
 	@if s="$$(gofmt -l $(go_srcs) 2>/dev/null)" && test -n "$$s"; then printf ' => %s\n%s\n' gofmt  "$$s"; false; fi
 	@if s="$$(golint   $(go_dirs) 2>/dev/null)" && test -n "$$s"; then printf ' => %s\n%s\n' golint "$$s"; false; fi
@@ -104,6 +108,7 @@ ifneq ($(filter arch,$(DIST_IDS)),)
 	install -D -m 0644 util/distribution-integration/alpm.hook    "$(DESTDIR)/usr/share/libalpm/hooks/01-holo-resolve-pacnew.hook"
 	install -D -m 0755 util/distribution-integration/alpm-hook.sh "$(DESTDIR)/usr/share/libalpm/scripts/holo-resolve-pacnew"
 endif
+.PHONY: install
 
 clean: clean-tests
 	rm -fr -- build/ .go-workspace/pkg/
@@ -112,10 +117,11 @@ clean-tests:
 	rm -fr -- test/*/*/target
 	rm -f -- test/*/*/{tree,{colored-,}{apply,apply-force,diff,scan}-output}
 	rm -f -- test/cov.* test/cov/* test/holo-*
+.PHONY: clean clean-tests
 
 vendor: FORCE
 	@# vendoring by https://github.com/holocm/golangvend
 	golangvend
+.PHONY: vendor
 
-.PHONY: test check install clean clean-tests vendor
 .PHONY: FORCE

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,7 @@ check-holo-test: clean-tests build/holo.test util/holo-test
 		true
 .PHONY: check-%
 
-test/cov.cov: cmd/holo/internal/go-test.cov
-test/cov.cov: cmd/holo-ssh-keys/impl/go-test.cov
+test/cov.cov: $(sort $(shell find $(filter-out %.go,$(go_srcs)) -name '*_test.go' -printf '%h/go-test.cov\n'))
 test/cov.cov: check-holo-test-help
 test/cov.cov: check-holo-test
 test/cov.cov: util/gocovcat.go

--- a/util/holo-test
+++ b/util/holo-test
@@ -61,7 +61,7 @@ run_testcase() (
     # with the "git diff --no-index -- FILE FILE" syntax, which changes the
     # diff-output of the unit tests for holo-files; to fix this, we put a
     # temporary git root at the $PWD)
-    git init >/dev/null
+    ( unset GIT_DIR; git init ) >/dev/null
 
     # setup environment for holo run
     export HOLO_ROOT_DIR="./target/"

--- a/util/holo-test
+++ b/util/holo-test
@@ -119,9 +119,11 @@ for TESTCASE in "$@"; do
     run_testcase $TESTCASE || TEST_EXIT_CODE=1
 done
 
-if [ $TEST_EXIT_CODE = 0 ]; then
-    echo ">> All tests for $TESTED_THING completed successfully."
-else
-    echo "!! Some or all tests for $TESTED_THING failed. Please check the output above for more information."
+if [ $# -gt 1 ]; then
+	if [ $TEST_EXIT_CODE = 0 ]; then
+		echo ">> All tests for $TESTED_THING completed successfully."
+	else
+		echo "!! Some or all tests for $TESTED_THING failed. Please check the output above for more information."
+	fi
 fi
 exit $TEST_EXIT_CODE


### PR DESCRIPTION
This pull request does two things:
 - Enables running the `make check` tests in parallel (if you give `-j${N}` to `make` or stick it in `$MAKEFLAGS`)
 - Automatically detects which packages need `go test`

I'm leaving this for you to merge, since you should be aware that it changes how `make check` works: By default, it will quit after the first check fails; to have it keep running checks, even after the first failure, run `make check -k` (the old behavior is to run the remaining tests for the current plugin; but then quit early).  If you have parallel builds enabled in for `make` (`-jN`), the test order will obviously be a little random; but without `-jN` (or with `-j1`), the test order should be what it was before.